### PR TITLE
Remove unnecessary alias file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,10 +20,6 @@ Gemspec/RequireMFA:
 Metrics:
   Enabled: false
 
-Naming/FileName:
-  Exclude:
-    - lib/rubocop-erb.rb
-
 RSpec/ExampleLength:
   Enabled: false
 

--- a/lib/rubocop-erb.rb
+++ b/lib/rubocop-erb.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require 'rubocop/erb'


### PR DESCRIPTION
Recent versions of RuboCop no longer require this file.