### PR TITLE
Fix version module capitalization

### DIFF
--- a/lib/rubocop/erb/version.rb
+++ b/lib/rubocop/erb/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Rubocop
+module RuboCop
   module Erb
     VERSION = '0.2.1'
   end

--- a/rubocop-erb.gemspec
+++ b/rubocop-erb.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/rubocop/erb/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'rubocop-erb'
-  spec.version = Rubocop::Erb::VERSION
+  spec.version = RuboCop::Erb::VERSION
   spec.authors = ['Ryo Nakamura']
   spec.email = ['r7kamura@gmail.com']
 


### PR DESCRIPTION
Makes `rubocop -V` include this extension. This is also the case for the other 3 extensions from the readme, but I'll leave that up to you.