### PR TITLE
Don't run release workflow on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,5 +8,6 @@ on:
 jobs:
   release:
     uses: r7kamura/workflows/.github/workflows/gem-release.yml@main
+    if: github.repository_owner == 'r7kamura'
     secrets:
       rubygems-org-api-key: ${{ secrets.RUBYGEMS_ORG_API_KEY }}


### PR DESCRIPTION
I synced my fork and noticed that it tried to run the release workflow which obviously failed. I'm not sure if this is the best way to do it or if the inherited workflow should be modified, but this works.