### PR TITLE
Fix syntax by removing keywords in more cases

### DIFF
--- a/lib/rubocop/erb/keyword_remover.rb
+++ b/lib/rubocop/erb/keyword_remover.rb
@@ -149,9 +149,9 @@ module RuboCop
           [ \t]
           do
           [ \t]*
-          (\|[^|]*\|)?
-          [ \t]*
-          \Z
+          (?:\|[^|]*\|)?
+          \s*
+          \z
         /x.freeze
       end
     end

--- a/lib/rubocop/erb/keyword_remover.rb
+++ b/lib/rubocop/erb/keyword_remover.rb
@@ -23,6 +23,7 @@ module RuboCop
           PrecedingKeywordRemover,
           PrecedingBraceRemover,
           TrailingBraceRemover,
+          TrailingThenRemover,
           TrailingDoRemover
         ].reduce(@ruby_clip) do |previous, callable|
           result = callable.call(previous.code)
@@ -127,6 +128,16 @@ module RuboCop
           {
           [ \t]*
           (?:\|[^|]*\|)?
+          \s*
+          \z
+        /x.freeze
+      end
+
+      # Remove trailing `then`.
+      class TrailingThenRemover < TrailingSourceRemover
+        REGEXP = /
+          [ \t]*\b
+          then
           \s*
           \z
         /x.freeze

--- a/spec/rubocop/erb/ruby_extractor_spec.rb
+++ b/spec/rubocop/erb/ruby_extractor_spec.rb
@@ -96,5 +96,22 @@ RSpec.describe RuboCop::Erb::RubyExtractor do
         expect(result).to be_empty
       end
     end
+
+    context 'with braces' do
+      let(:source) do
+        <<~ERB
+          <%= foo.each { |a, b| %>
+            <br>
+          <% } %>
+        ERB
+      end
+
+      it 'ignores both opening and closing braces' do
+        result = subject
+        expect(result.length).to eq(1)
+        expect(result[0][:processed_source].raw_source).to eq(' foo.each ')
+        expect(result[0][:offset]).to eq(3)
+      end
+    end
   end
 end

--- a/spec/rubocop/erb/ruby_extractor_spec.rb
+++ b/spec/rubocop/erb/ruby_extractor_spec.rb
@@ -128,5 +128,21 @@ RSpec.describe RuboCop::Erb::RubyExtractor do
         expect(result[0][:offset]).to eq(7)
       end
     end
+
+    context 'with trailing newline after `do`' do
+      let(:source) do
+        <<~ERB
+          <% foo.each do
+           %>
+        ERB
+      end
+
+      it 'ignores `do`' do
+        result = subject
+        expect(result.length).to eq(1)
+        expect(result[0][:processed_source].raw_source).to eq(' foo.each')
+        expect(result[0][:offset]).to eq(2)
+      end
+    end
   end
 end

--- a/spec/rubocop/erb/ruby_extractor_spec.rb
+++ b/spec/rubocop/erb/ruby_extractor_spec.rb
@@ -113,5 +113,20 @@ RSpec.describe RuboCop::Erb::RubyExtractor do
         expect(result[0][:offset]).to eq(3)
       end
     end
+
+    context 'with trailing `then`' do
+      let(:source) do
+        <<~ERB
+          <%= if foo then %>
+        ERB
+      end
+
+      it 'ignores `then`' do
+        result = subject
+        expect(result.length).to eq(1)
+        expect(result[0][:processed_source].raw_source).to eq('foo')
+        expect(result[0][:offset]).to eq(7)
+      end
+    end
   end
 end


### PR DESCRIPTION
Handle three more cases where the content of an erb tag is invalid Ruby syntax when parsed in isolation.