### PR TITLE
Disable `Layout/CommentIndentation`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -23,6 +23,10 @@ Layout/ClosingParenthesisIndentation:
   Exclude:
     - '**/*.erb'
 
+Layout/CommentIndentation:
+  Exclude:
+    - '**/*.erb'
+
 Layout/InitialIndentation:
   Exclude:
     - '**/*.erb'


### PR DESCRIPTION
Since there are so many patterns in ERB that can be taken as false positives, we will disable this cop.