### PR TITLE
Bump `actions/checkout` to v4

### DIFF
--- a/.github/workflows/bump-request.yml
+++ b/.github/workflows/bump-request.yml
@@ -12,7 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Gets rid of an actions deprecation warning:
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3

https://github.com/r7kamura/rubocop-erb/actions/runs/10282951053
