### PR TITLE
Use the configured ruby version instead of `current` for `WhenDecomposer

### DIFF
--- a/lib/rubocop/erb.rb
+++ b/lib/rubocop/erb.rb
@@ -4,6 +4,7 @@ module RuboCop
   module Erb
     autoload :ConfigLoader, 'rubocop/erb/config_loader'
     autoload :KeywordRemover, 'rubocop/erb/keyword_remover'
+    autoload :ProcessedSourceHelper, 'rubocop/erb/processed_source_helper'
     autoload :RubyClip, 'rubocop/erb/ruby_clip'
     autoload :RubyExtractor, 'rubocop/erb/ruby_extractor'
     autoload :WhenDecomposer, 'rubocop/erb/when_decomposer'

--- a/lib/rubocop/erb/processed_source_helper.rb
+++ b/lib/rubocop/erb/processed_source_helper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Erb
+    module ProcessedSourceHelper
+      # Creates a new ProcessedSource, inheriting state from a donor
+      #
+      # @param [RuboCop::ProcessedSource] input_processed_source
+      # @param [String] code
+      # @return [RuboCop::ProcessedSource]
+      def self.code_to_processed_source(input_processed_source, path, code)
+        supports_prism = input_processed_source.respond_to?(:parser_engine)
+        processed_source = if supports_prism
+                             ::RuboCop::ProcessedSource.new(
+                               code,
+                               input_processed_source.ruby_version,
+                               path,
+                               parser_engine: input_processed_source.parser_engine
+                             )
+                           else
+                             ::RuboCop::ProcessedSource.new(
+                               code,
+                               input_processed_source.ruby_version,
+                               path
+                             )
+                           end
+        processed_source.config = input_processed_source.config
+        processed_source.registry = input_processed_source.registry
+        processed_source
+      end
+    end
+  end
+end

--- a/lib/rubocop/erb/when_decomposer.rb
+++ b/lib/rubocop/erb/when_decomposer.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'parser/current'
-require 'rubocop/ast/builder'
-
 module RuboCop
   module Erb
     class WhenDecomposer
@@ -13,15 +10,24 @@ module RuboCop
       /x.freeze
 
       class << self
+        # @param [RuboCop::ProcessedSource] processed_source
         # @param [RuboCop::Erb::RubyClip] ruby_clip
         # @return [Array<RuboCop::Erb::RubyClip>]
-        def call(ruby_clip)
-          new(ruby_clip).call
+        def call(
+          processed_source,
+          ruby_clip
+        )
+          new(processed_source, ruby_clip).call
         end
       end
 
+      # @param [RuboCop::ProcessedSource] processed_source
       # @param [RuboCop::Erb::RubyClip] ruby_clip
-      def initialize(ruby_clip)
+      def initialize(
+        processed_source,
+        ruby_clip
+      )
+        @processed_source = processed_source
         @ruby_clip = ruby_clip
       end
 
@@ -53,14 +59,11 @@ module RuboCop
       # @param [String] source
       # @return [RuboCop::AST::Node]
       def parse(source)
-        ::Parser::CurrentRuby.new(
-          ::RuboCop::AST::Builder.new
-        ).parse(
-          ::Parser::Source::Buffer.new(
-            '(string)',
-            source: source
-          )
-        )
+        ProcessedSourceHelper.code_to_processed_source(
+          @processed_source,
+          '(string)',
+          source
+        ).ast
       end
     end
   end


### PR DESCRIPTION
This one has been bothering me for a while. When requiring `parser/current`, it checks if the executing ruby patch version is the expected one. If it isn't, it will show a warning:
> warning: parser/current is loading parser/ruby33, which recognizes 3.3.4-compliant syntax, but you are running 3.3.3

RuboCop doesn't show this because it requires specific parser versions that can't possibly warn about this.

This is also technically more correct, though I'm not quite sure if that even matters.

RuboCop output may look like this when updating `parser` and running with an older patch version:

```
Inspecting 220 files
......................................................................................warning: parser/current is loading parser/ruby33, which recognizes 3.3.4-compliant syntax, but you are running 3.3.3.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.....................................................................................................................................
```