### PR TITLE
Fix bug that `Lint/Syntax` is not properly disabled

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -143,7 +143,7 @@ Lint/OutOfRangeRegexpRef:
   Exclude:
     - '**/*.erb'
 
-Lint/SyntaxError:
+Lint/Syntax:
   Exclude:
     - '**/*.erb'
 


### PR DESCRIPTION
Same as:

- https://github.com/r7kamura/rubocop-slim/pull/27