### PR TITLE
Don't disable `Lint/Syntax`, filter in code instead

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -143,10 +143,6 @@ Lint/OutOfRangeRegexpRef:
   Exclude:
     - '**/*.erb'
 
-Lint/Syntax:
-  Exclude:
-    - '**/*.erb'
-
 Lint/UselessAssignment:
   Exclude:
     - '**/*.erb'

--- a/lib/rubocop/erb/ruby_extractor.rb
+++ b/lib/rubocop/erb/ruby_extractor.rb
@@ -25,13 +25,16 @@ module RuboCop
       def call
         return unless supported_file_path_pattern?
 
-        ruby_clips.map do |ruby_clip|
+        ruby_clips.filter_map do |ruby_clip|
+          processed_source = ProcessedSourceBuilder.call(
+            code: ruby_clip.code,
+            processed_source: @processed_source
+          )
+          next unless processed_source.valid_syntax?
+
           {
             offset: ruby_clip.offset,
-            processed_source: ProcessedSourceBuilder.call(
-              code: ruby_clip.code,
-              processed_source: @processed_source
-            )
+            processed_source: processed_source
           }
         end
       end

--- a/spec/rubocop/erb/ruby_extractor_spec.rb
+++ b/spec/rubocop/erb/ruby_extractor_spec.rb
@@ -181,5 +181,21 @@ RSpec.describe RuboCop::Erb::RubyExtractor do
         expect(result[0][:offset]).to eq(2)
       end
     end
+
+    context 'with a syntax error' do
+      let(:source) do
+        <<~ERB
+          <% h!.2 %>
+          <% "foo" %>
+        ERB
+      end
+
+      it 'ignores the clip' do
+        result = subject
+        expect(result.length).to eq(1)
+        expect(result[0][:processed_source].raw_source).to eq(' "foo" ')
+        expect(result[0][:offset]).to eq(13)
+      end
+    end
   end
 end


### PR DESCRIPTION
I don't consider it a good idea to rely on this working. RuboCop does a bunch of things to make it impossible to disable, and this working right now seems like a bug to me.

Instead, reject invalid invalid syntax snippets in the extractor.