### PR TITLE
Migrate from `better_html` to `herb`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        rubygems: latest
     - run: PARSER_ENGINE=${{ matrix.parser_engine }} bundle exec rspec
     - run: bundle exec rubocop --format progress --format github

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,13 @@ PATH
   remote: .
   specs:
     rubocop-erb (0.6.0)
-      better_html
+      herb (~> 0.7)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (7.1.5.1)
-      activesupport (= 7.1.5.1)
-      builder (~> 3.1)
-      erubi (~> 1.11)
-      rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.6)
     activesupport (7.1.5.1)
       base64
       benchmark (>= 0.3)
@@ -31,51 +25,27 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     benchmark (0.4.0)
-    better_html (2.1.1)
-      actionview (>= 6.0)
-      activesupport (>= 6.0)
-      ast (~> 2.0)
-      erubi (~> 1.4)
-      parser (>= 2.4)
-      smart_properties
     bigdecimal (3.1.9)
-    builder (3.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
-    crass (1.0.6)
     diff-lcs (1.6.0)
     drb (2.2.1)
-    erubi (1.13.1)
+    herb (0.7.1)
+    herb (0.7.1-x86_64-linux-gnu)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.10.1)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.6.6)
-    loofah (2.24.0)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.12.0)
-    mini_portile2 (2.8.8)
     minitest (5.25.4)
     mutex_m (0.3.0)
-    nokogiri (1.17.2)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.17.2-x86_64-linux)
-      racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     prism (1.3.0)
     racc (1.8.1)
-    rails-dom-testing (2.2.0)
-      activesupport (>= 5.0.0)
-      minitest
-      nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
-      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.10.0)
@@ -116,7 +86,6 @@ GEM
     sevencop (0.47.0)
       activesupport
       rubocop
-    smart_properties (1.17.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)

--- a/rubocop-erb.gemspec
+++ b/rubocop-erb.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'better_html'
+  spec.add_dependency 'herb', '~> 0.7'
   spec.add_dependency 'lint_roller', '~> 1.1'
   spec.add_dependency 'rubocop', '~> 1.72', '>= 1.72.1'
 end


### PR DESCRIPTION
- Closes https://github.com/r7kamura/rubocop-erb/issues/57

One caveat is that herb never supported Ruby 2.7, so I bumped the minimum version to 3.0.