### PR TITLE
Change bundler version from 2.3.19 to 2.5.23

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   sevencop
 
 BUNDLED WITH
-   2.3.19
+   2.5.23


### PR DESCRIPTION
The latest version that can be installed on ruby 3.0 is bundler 2.5.23.

Since `Gemfile.lock` is used in CI for ruby 3.0 and later, this setup is necessary. Meanwhile, ruby 2.7 is handled with a separate `gemfiles/ruby_2.7.gemfile.lock`, so there’s no issue there.
